### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Deep Learning for Visual Question Answering
+# Deep Learning for Visual Question Answering
 
 [Click here](https://avisingh599.github.io/deeplearning/visual-qa/) to go to the accompanying blog post. 
 
@@ -11,7 +11,7 @@ Models Implemented:
 | <img src="https://raw.githubusercontent.com/avisingh599/homepage/master/images/vqa/model_1.jpg" alt="alt text" width="400" height=""> | <img src="https://raw.githubusercontent.com/avisingh599/homepage/master/images/vqa/lstm_encoder.jpg" alt="alt text" width="300" height="whatever"> |
 
 
-##Requirements
+## Requirements
 1. [Keras 0.20](http://keras.io/)
 2. [spaCy 0.94](http://spacy.io/)
 3. [scikit-learn 0.16](http://scikit-learn.org/)
@@ -29,7 +29,7 @@ Tested with Python 2.7 on Ubuntu 14.04 and Centos 7.1.
 4. VQA Tools is **not** needed. 
 5. Caffe (Optional) - For using the VQA with your own images.
 
-##Installation Guide
+## Installation Guide
 This project has a large number of dependecies, and I am yet to make a comprehensive installation guide. In the meanwhile, you can use the following guide made by @gajumaru4444:
 
 1. [Prepare for VQA in Ubuntu 14.04 x64 Part 1](https://gajumaru4444.github.io/2015/11/10/Visual-Question-Answering-2.html)
@@ -37,12 +37,12 @@ This project has a large number of dependecies, and I am yet to make a comprehen
 
 If you intend to use my pre-trained models, you would also need to replace spaCy's deafult word vectors with the GloVe word vectors from Stanford. You can find more details [here](http://spacy.io/tutorials/load-new-word-vectors/) on how to do this.
 
-##Using Pre-trained models
+## Using Pre-trained models
 Take a look at `scripts/demo_batch.py`. An LSTM-based pre-trained model has been released. It currently works only on the images of the MS COCO dataset (need to be downloaded separately), since I have pre-computed the VGG features for them. I do intend to add a pipeline for computing features for other images.
 
 **Caution**: Use the pre-trained model with 300D Common Crawl Glove Word Embeddings. Do not the the default spaCy embeddings (Goldberg and Levy 2014). If you try to use these pre-trained models with any embeddings except Glove, your results would be **garbage**. You can find more deatails [here](http://spacy.io/tutorials/load-new-word-vectors/) on how to do this.
 
-##Using your own images
+## Using your own images
 
 Now you can use your own images with the `scripts/own_image.py` script. Use it like : 
 
@@ -50,7 +50,7 @@ python own_image.py --caffe /path/to/caffe
 
 For now, a Caffe installation is required. However, I'm working on a Keras based VGG Net which should be up soon. Download the VGG Caffe model weights from [here](http://www.robots.ox.ac.uk/~vgg/software/very_deep/caffe/VGG_ILSVRC_16_layers.caffemodel) and place it in the scripts folder.
 
-##The Numbers
+## The Numbers
 Performance on the **validation set** and the **test-dev set** of the [VQA Challenge](http://visualqa.org/challenge.html):
 
 | Model     		   | val           | test-dev      |
@@ -72,11 +72,11 @@ Training Time on various hardware:
 
 The above numbers are valid when using a batch size of `128`, and training on 215K examples in every epoch.
 
-##Get Started
+## Get Started
 Have a look at the `get_started.sh` script in the `scripts` folder. Also, have a look at the readme present in each of the folders.
 
-##Feedback
+## Feedback
 All kind of feedback (code style, bugs, comments etc.) is welcome. Please open an issue on this repo instead of mailing me, since it helps me keep track of things better.
 
-##License
+## License
 MIT


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
